### PR TITLE
These are fixes to the recent breakage within portions of the GitHub community

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 .DS_Store
 ._*
+/.idea/*

--- a/cpp-hocon.rb
+++ b/cpp-hocon.rb
@@ -1,7 +1,7 @@
 class CppHocon < Formula
   desc "A C++ port of the Typesafe Config library."
   homepage "https://github.com/puppetlabs/cpp-hocon"
-  head "https://github.com/puppetlabs/cpp-hocon.git"
+  head "https://github.com/puppetlabs/cpp-hocon.git", branch: "main"
 
   depends_on "cmake"      => :build
   depends_on "leatherman" => :build

--- a/cpp-hocon.rb
+++ b/cpp-hocon.rb
@@ -1,7 +1,7 @@
 class CppHocon < Formula
   desc "A C++ port of the Typesafe Config library."
   homepage "https://github.com/puppetlabs/cpp-hocon"
-  head "https://github.com/puppetlabs/cpp-hocon.git"
+  head "https://github.com/puppetlabs/cpp-hocon.git", branch: "master"
 
   depends_on "cmake"      => :build
   depends_on "leatherman" => :build

--- a/facter.rb
+++ b/facter.rb
@@ -1,7 +1,7 @@
 class Facter < Formula
   desc "Collect and display system facts"
   homepage "https://tickets.puppet.com/browse/FACT"
-  head "https://github.com/puppetlabs/facter.git"
+  head "https://github.com/puppetlabs/facter.git", branch: "main"
 
   depends_on "cmake"      => :build
   depends_on "cpp-hocon"  => :build

--- a/leatherman.rb
+++ b/leatherman.rb
@@ -1,7 +1,7 @@
 class Leatherman < Formula
   desc "A collection of C++ and CMake utility libraries."
   homepage "https://github.com/puppetlabs/leatherman"
-  head "https://github.com/puppetlabs/leatherman.git"
+  head "https://github.com/puppetlabs/leatherman.git", branch: "main"
 
   depends_on "cmake" => :build
 

--- a/libwhereami.rb
+++ b/libwhereami.rb
@@ -1,7 +1,7 @@
 class Libwhereami < Formula
   desc "libwhereami detects virtualization environments."
   homepage "https://github.com/puppetlabs/libwhereami"
-  head "https://github.com/puppetlabs/libwhereami.git"
+  head "https://github.com/puppetlabs/libwhereami.git", branch: "main"
 
   depends_on "cmake"      => :build
   depends_on "leatherman" => :build


### PR DESCRIPTION
Some people thought it would be brilliant to change the convention described in the Git documentation and are renaming their primary branch to "main", deleting the old branch, breaking a decade worth of gems.